### PR TITLE
Add debug middleware

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/HewlettPackard/hpegl-pcbe-terraform-resources/internal/auth"
+	"github.com/HewlettPackard/hpegl-pcbe-terraform-resources/internal/debug"
 	"github.com/HewlettPackard/hpegl-pcbe-terraform-resources/internal/defaults"
 	"github.com/HewlettPackard/hpegl-pcbe-terraform-resources/internal/sdk/async"
 	"github.com/HewlettPackard/hpegl-pcbe-terraform-resources/internal/sdk/systems"
@@ -32,6 +33,12 @@ func (c *PCBeClient) NewAsyncClient(ctx context.Context) (*async.ApiClient, erro
 	tp := auth.NewPcbeAccessTokenProvider(c.Config.Token)
 	authProvider := authentication.NewBaseBearerTokenAuthenticationProvider(tp)
 	observeOpts := nethttplibrary.ObservabilityOptions{}
+	if c.Config.HTTPDump {
+		debugOpts := debug.NewInspectionOptions()
+		debugOpts.Enabled = true
+		debugOptsHandler := debug.NewInspectionHandlerWithOptions(*debugOpts)
+		middlewares = append(middlewares, debugOptsHandler)
+	}
 	headerOpts := nethttplibrary.NewHeadersInspectionOptions()
 	headerOpts.InspectResponseHeaders = true
 	headerOptsHandler := nethttplibrary.NewHeadersInspectionHandlerWithOptions(*headerOpts)
@@ -58,6 +65,12 @@ func (c *PCBeClient) NewVirtClient(
 	tp := auth.NewPcbeAccessTokenProvider(c.Config.Token)
 	authProvider := authentication.NewBaseBearerTokenAuthenticationProvider(tp)
 	observeOpts := nethttplibrary.ObservabilityOptions{}
+	if c.Config.HTTPDump {
+		debugOpts := debug.NewInspectionOptions()
+		debugOpts.Enabled = true
+		debugOptsHandler := debug.NewInspectionHandlerWithOptions(*debugOpts)
+		middlewares = append(middlewares, debugOptsHandler)
+	}
 	headerOpts := nethttplibrary.NewHeadersInspectionOptions()
 	headerOpts.InspectResponseHeaders = true
 	headerOptsHandler := nethttplibrary.NewHeadersInspectionHandlerWithOptions(*headerOpts)
@@ -84,6 +97,12 @@ func (c *PCBeClient) NewSysClient(
 	tp := auth.NewPcbeAccessTokenProvider(c.Config.Token)
 	authProvider := authentication.NewBaseBearerTokenAuthenticationProvider(tp)
 	observeOpts := nethttplibrary.ObservabilityOptions{}
+	if c.Config.HTTPDump {
+		debugOpts := debug.NewInspectionOptions()
+		debugOpts.Enabled = true
+		debugOptsHandler := debug.NewInspectionHandlerWithOptions(*debugOpts)
+		middlewares = append(middlewares, debugOptsHandler)
+	}
 	headerOpts := nethttplibrary.NewHeadersInspectionOptions()
 	headerOpts.InspectResponseHeaders = true
 	headerOptsHandler := nethttplibrary.NewHeadersInspectionHandlerWithOptions(*headerOpts)

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -1,0 +1,71 @@
+package debug
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httputil"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/microsoft/kiota-abstractions-go"
+	"github.com/microsoft/kiota-http-go"
+)
+
+type InspectionOptions struct {
+	Enabled         bool
+	RequestHeaders  *abstractions.RequestHeaders
+	ResponseHeaders *abstractions.ResponseHeaders
+}
+type InspectionHandler struct {
+	options InspectionOptions
+}
+
+func (middleware InspectionHandler) Intercept(
+	pipeline nethttplibrary.Pipeline,
+	middlewareIndex int,
+	req *http.Request,
+) (*http.Response, error) {
+	var bodyBytes []byte
+	var err error
+
+	if req.Body != nil {
+		bodyBytes, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+	}
+	reqBytes, err := httputil.DumpRequestOut(req, true)
+	if err != nil {
+		return nil, err
+	}
+
+	tflog.Info(req.Context(),
+		"\n\n->TX\n\n"+
+			string(reqBytes)+
+			"--\n")
+
+	resp, err := pipeline.Next(req, middlewareIndex)
+
+	respBytes, _ := httputil.DumpResponse(resp, true)
+	tflog.Info(req.Context(),
+		"\n\n<-RX\n\n"+
+			string(respBytes)+
+			"\n--\n")
+
+	return resp, err
+}
+
+func NewInspectionOptions() *InspectionOptions {
+	return &InspectionOptions{
+		Enabled:         false,
+		RequestHeaders:  abstractions.NewRequestHeaders(),
+		ResponseHeaders: abstractions.NewResponseHeaders(),
+	}
+}
+
+func NewInspectionHandlerWithOptions(
+	options InspectionOptions,
+) *InspectionHandler {
+	return &InspectionHandler{options: options}
+}


### PR DESCRIPTION
When enabled, this will produce output such as:

```
->TX

POST /virtualization/v1beta1/datastores HTTP/1.1
Host: localhost:8080
User-Agent: Go-http-client/1.1
Transfer-Encoding: chunked
Accept: application/json
Authorization: Bearer abcdefghijklmnopqrstuvwxyz-0123456789
Content-Type: application/json
Accept-Encoding: gzip

{"name":"foo-ds19","sizeInBytes":17179869184,"storageSystemId":"127fd201-9e6e-5e31-9ffb-a766265b1fd3","targetHypervisorClusterId":"","volumeInfo":{"deduplication":false,"encryption":{"cipher":"None"},"qos":{"iopsLimit":-1,"mbpsLimit":-1}},"datastoreType":"VMFS"}

```

to stdout when running terraform.