### PR TITLE
Add build-experimental make target

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,4 +15,5 @@ jobs:
           go-version: ${{ matrix.go }}
       - run: go version
       - run: make build
+      - run: make build-experimental
       - run: make test

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@
 build:
 	go build ./...
 
+build-experimental:
+	go build -tags experimental ./...
+
 test:
 	go test ./...
 


### PR DESCRIPTION
This allows use of an "experimental" build tag to
control which code to release, without relying on
branches.