### PR TITLE
Add make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@
 build:
 	go build ./...
 
-build-experimental:
-	go build -tags experimental ./...
+install:
+	go install ./...
 
 test:
 	go test ./...
@@ -15,3 +15,9 @@ lint:
 	@golangci-lint --version
 	# Will use .golangci.yml
 	golangci-lint run
+
+build-experimental:
+	go build -tags experimental ./...
+
+install-experimental:
+	go install -tags experimental  ./...

--- a/cmd/terraform-provider-hpegl-pcbe-terraform-resources/main.go
+++ b/cmd/terraform-provider-hpegl-pcbe-terraform-resources/main.go
@@ -3,10 +3,15 @@
 package main
 
 import (
+	"context"
 	"flag"
+	"log"
 
+	"github.com/HewlettPackard/hpegl-pcbe-terraform-resources/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 )
+
+var version = "dev"
 
 func main() {
 	var debug bool
@@ -16,8 +21,13 @@ func main() {
 	)
 	flag.Parse()
 
-	_ = providerserver.ServeOpts{
+	opts := providerserver.ServeOpts{
 		Address: "github.com/HewlettPackard/hpegl-pcbe-terraform-resources",
 		Debug:   debug,
+	}
+
+	err := providerserver.Serve(context.Background(), provider.New(version), opts)
+	if err != nil {
+		log.Fatal(err.Error())
 	}
 }


### PR DESCRIPTION
As part of this change rename main.go so that "go install" produces a file called "terraform-provider-hpegl-pcbe-terraform-resources".

The prefix "terraform-provider-" is required for terraform apply to work.