### PR TITLE
Enable "system" datasources

### DIFF
--- a/internal/provider/datasources.go
+++ b/internal/provider/datasources.go
@@ -1,0 +1,18 @@
+// (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+
+//go:build !experimental
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+)
+
+// DataSources defines the data sources implemented in the provider.
+func (p *PCBeProvider) DataSources(
+	_ context.Context,
+) []func() datasource.DataSource {
+	return []func() datasource.DataSource{}
+}

--- a/internal/provider/experimental_datasources.go
+++ b/internal/provider/experimental_datasources.go
@@ -1,0 +1,20 @@
+// (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+
+//go:build experimental
+
+package provider
+
+import (
+	"context"
+	"github.com/HewlettPackard/hpegl-pcbe-terraform-resources/internal/datasources/system"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+)
+
+// DataSources defines the data sources implemented in the provider.
+func (p *PCBeProvider) DataSources(
+	_ context.Context,
+) []func() datasource.DataSource {
+	return []func() datasource.DataSource{
+		system.NewDataSource,
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -8,7 +8,6 @@ import (
 	"github.com/HewlettPackard/hpegl-pcbe-terraform-resources/internal/client"
 	"github.com/HewlettPackard/hpegl-pcbe-terraform-resources/internal/constants"
 	"github.com/HewlettPackard/hpegl-pcbe-terraform-resources/internal/defaults"
-	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
@@ -167,13 +166,6 @@ func (p *PCBeProvider) Configure(
 
 	resp.DataSourceData = client
 	resp.ResourceData = client
-}
-
-// DataSources defines the data sources implemented in the provider.
-func (p *PCBeProvider) DataSources(
-	_ context.Context,
-) []func() datasource.DataSource {
-	return []func() datasource.DataSource{}
 }
 
 // Resources defines the resources implemented in the provider.


### PR DESCRIPTION
Allow creating "system" datasources when the experimental build tag is set.