### PR TITLE
Enable datastore as experimental resource

### DIFF
--- a/internal/provider/experimental_resources.go
+++ b/internal/provider/experimental_resources.go
@@ -1,0 +1,20 @@
+// (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+
+//go:build experimental
+
+package provider
+
+import (
+	"context"
+	"github.com/HewlettPackard/hpegl-pcbe-terraform-resources/internal/resources/datastore"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+// Resources defines the resources implemented in the provider.
+func (p *PCBeProvider) Resources(
+	_ context.Context,
+) []func() resource.Resource {
+	return []func() resource.Resource{
+		datastore.NewResource,
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -166,11 +165,4 @@ func (p *PCBeProvider) Configure(
 
 	resp.DataSourceData = client
 	resp.ResourceData = client
-}
-
-// Resources defines the resources implemented in the provider.
-func (p *PCBeProvider) Resources(
-	_ context.Context,
-) []func() resource.Resource {
-	return []func() resource.Resource{}
 }

--- a/internal/provider/resources.go
+++ b/internal/provider/resources.go
@@ -1,0 +1,18 @@
+// (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+
+//go:build !experimental
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+// Resources defines the resources implemented in the provider.
+func (p *PCBeProvider) Resources(
+	_ context.Context,
+) []func() resource.Resource {
+	return []func() resource.Resource{}
+}


### PR DESCRIPTION
Now, if the provider is built using the 'experimental' tag 
it should be possible to create datastore resources.