### PR TITLE
Include 'id' in datastore read

### DIFF
--- a/internal/resources/datastore/resource.go
+++ b/internal/resources/datastore/resource.go
@@ -128,7 +128,7 @@ func doRead(
 		return
 	}
 
-	datastoreID := (*dataP).Id.ValueString()
+	IDFromState := (*dataP).Id.ValueString()
 
 	grc := virtualization.
 		V1beta1DatastoresDatastoresItemRequestBuilderGetRequestConfiguration{}
@@ -136,7 +136,7 @@ func doRead(
 	datastore, err := virtClient.Virtualization().
 		V1beta1().
 		Datastores().
-		ById(datastoreID).
+		ById(IDFromState).
 		GetAsDatastoresGetResponse(ctx, &grc)
 	if err != nil {
 		(*diagsP).AddError(
@@ -146,6 +146,18 @@ func doRead(
 
 		return
 	}
+
+	datastoreID := datastore.GetId()
+	if datastoreID == nil {
+		(*diagsP).AddError(
+			"error reading datastore",
+			"'id' is nil",
+		)
+
+		return
+	}
+
+	(*dataP).Id = types.StringValue(*datastoreID)
 
 	datastoreName := datastore.GetName()
 	if datastoreName == nil {


### PR DESCRIPTION
The datastore 'id' returned in the datastore read
response should be the same as the 'id' used in the GET request.
Nevertheless we use the returned value, mainly to detect the
extremely unlikely case where the API returns an unexpected 'id' value.