### PR TITLE
Handle hypervisor cluster id mismatch

### DIFF
--- a/internal/resources/hypervisorcluster/resource.go
+++ b/internal/resources/hypervisorcluster/resource.go
@@ -4,6 +4,7 @@ package hypervisorcluster
 
 import (
 	"context"
+	"fmt"
 	"path"
 
 	"github.com/HewlettPackard/hpegl-pcbe-terraform-resources/internal/client"
@@ -91,6 +92,25 @@ func doRead(
 		(*diagsP).AddError(
 			"error reading hypervisor cluster "+hypervisorClusterID,
 			"unexpected error: "+err.Error(),
+		)
+
+		return
+	}
+
+	if getResp.GetId() == nil {
+		(*diagsP).AddError(
+			"error reading hypervisor cluster "+hypervisorClusterID,
+			"'id' is nil",
+		)
+
+		return
+	}
+
+	if *(getResp.GetId()) != hypervisorClusterID {
+		(*diagsP).AddError(
+			"error reading hypervisor cluster "+hypervisorClusterID,
+			fmt.Sprintf("'id' mismatch: %s != %s",
+				*(getResp.GetId()), hypervisorClusterID),
 		)
 
 		return


### PR DESCRIPTION
Handle the corner case where a returned id may not match the id
in the current terraform state.  This should never happen because id's are immutable.

If it does ever occur we will not overwrite any state and will instead raise this error:

```
Error: error reading hypervisor cluster 298a299e-78f5-5acb-86ce-4e9fdc290ab7

  with hpegl_pc_hypervisor_cluster.test,
  on terraform_plugin_test.tf line 21, in resource "hpegl_pc_hypervisor_cluster" "test":
  21:   resource "hpegl_pc_hypervisor_cluster" "test" {

'id' mismatch: 298a299e-78f5-5acb-86ce-4e9fdc290ab7 !=
298a299e-78f5-5acb-86ce-4e9fdc290ab7
```