### PR TITLE
Handle server id mismatch

### DIFF
--- a/internal/resources/server/resource.go
+++ b/internal/resources/server/resource.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/HewlettPackard/hpegl-pcbe-terraform-resources/internal/client"
 	"github.com/HewlettPackard/hpegl-pcbe-terraform-resources/internal/sdk/systems/privatecloudbusiness"
@@ -96,6 +97,17 @@ func doRead(
 		(*diagsP).AddError(
 			"error reading server",
 			"'id' is nil",
+		)
+
+		return
+	}
+
+	if *(server.GetId()) != serverID {
+		(*diagsP).AddError(
+			"error reading server",
+			fmt.Sprintf("'id' mismatch: %s != %s",
+				*(server.GetId()), serverID,
+			),
 		)
 
 		return


### PR DESCRIPTION
Handle the corner case where a returned server id
may not match the id in the current terraform state.
This should never happen because id's are immutable.

If it does ever occur we will not overwrite any state and will
instead raise this error:

```
Error: error reading server

  with hpegl_pc_server.test,
  on terraform_plugin_test.tf line 21, in resource "hpegl_pc_server" "test":
  21:   resource "hpegl_pc_server" "test" {

'id' mismatch: 697e8cbf-df7e-570c-a3c7-912d4ce8375a !=
697e8cbf-df7e-570c-a3c7-912d4ce8375a
```