### PR TITLE
hciClusterUuid mismatch for hypervisor cluster

### DIFF
--- a/internal/resources/hypervisorcluster/resource.go
+++ b/internal/resources/hypervisorcluster/resource.go
@@ -116,6 +116,28 @@ func doRead(
 		return
 	}
 
+	if getResp.GetHciClusterUuid() == nil {
+		(*diagsP).AddError(
+			"error reading hypervisor cluster "+hypervisorClusterID,
+			"'hciClusterUuid' is nil",
+		)
+
+		return
+	}
+
+	systemID := (*dataP).HciClusterUuid.ValueString()
+	if *(getResp.GetHciClusterUuid()) != systemID {
+		(*diagsP).AddError(
+			"error reading hypervisor cluster "+hypervisorClusterID,
+			fmt.Sprintf("'hciClusterUuid' mismatch: %s != %s",
+				*(getResp.GetHciClusterUuid()), systemID),
+		)
+
+		return
+	}
+
+	(*dataP).HciClusterUuid = types.StringValue(*(getResp.GetHciClusterUuid()))
+
 	if getResp.GetName() == nil {
 		(*diagsP).AddError(
 			"error reading hypervisor cluster "+hypervisorClusterID,
@@ -126,17 +148,6 @@ func doRead(
 	}
 
 	(*dataP).Name = types.StringValue(*(getResp.GetName()))
-
-	if getResp.GetHciClusterUuid() == nil {
-		(*diagsP).AddError(
-			"error reading hypervisor cluster "+hypervisorClusterID,
-			"'hciClusterUuid' is nil",
-		)
-
-		return
-	}
-
-	(*dataP).HciClusterUuid = types.StringValue(*(getResp.GetHciClusterUuid()))
 
 	if getResp.GetAppInfo() == nil {
 		(*diagsP).AddError(


### PR DESCRIPTION
Handle the case where the system id unexpectedly changes.

Return an error like this:

```
│ Error: error reading hypervisor cluster 298a299e-78f5-5acb-86ce-4e9fdc290ab7
│
│   with hpegl_pc_hypervisor_cluster.my_hypervisor_cluster,
│   on main.tf line 45, in resource "hpegl_pc_hypervisor_cluster" "my_hypervisor_cluster":
│   45: resource "hpegl_pc_hypervisor_cluster" "my_hypervisor_cluster" {
│
│ 'hciClusterUuid' mismatch: 126fd201-9e6e-5e31-9ffb-a766265b1fd3 != 226fd201-9e6e-5e31-9ffb-a766265b1fd3
```