### PR TITLE
Handle system id mismatch for datastore

### DIFF
--- a/internal/resources/datastore/resource.go
+++ b/internal/resources/datastore/resource.go
@@ -167,6 +167,27 @@ func doRead(
 		return
 	}
 
+	if datastore.GetHciClusterUuid() == nil {
+		(*diagsP).AddError(
+			"error reading datastore",
+			"'hciClusterUuid' is nil",
+		)
+
+		return
+	}
+
+	systemID := (*dataP).HciClusterUuid.ValueString()
+	if *(datastore.GetHciClusterUuid()) != systemID {
+		(*diagsP).AddError(
+			"error reading datastore",
+			fmt.Sprintf("'hciClusterUuid' mismatch: %s != %s",
+				*(datastore.GetHciClusterUuid()), systemID,
+			),
+		)
+
+		return
+	}
+
 	datastoreName := datastore.GetName()
 	if datastoreName == nil {
 		(*diagsP).AddError(


### PR DESCRIPTION
If the system id underpinning a datastore unexpectedly changes,
raise the following error:

```
Error: error reading datastore

  with hpegl_pc_datastore.my_datastore,
  on main.tf line 27, in resource "hpegl_pc_datastore" "my_datastore":
  27: resource "hpegl_pc_datastore" "my_datastore" {

'hciClusterUuid' mismatch: 126fd201-9e6e-5e31-9ffb-a766265b1fd3 != 326fd201-9e6e-5e31-9ffb-a766265b1fd3
```