### PR TITLE
Handle system id mismatch for server

### DIFF
--- a/internal/resources/server/resource.go
+++ b/internal/resources/server/resource.go
@@ -113,6 +113,26 @@ func doRead(
 		return
 	}
 
+	if server.GetSystemId() == nil {
+		(*diagsP).AddError(
+			"error reading server",
+			"'systemId' is nil",
+		)
+
+		return
+	}
+
+	if *(server.GetSystemId()) != systemID {
+		(*diagsP).AddError(
+			"error reading server",
+			fmt.Sprintf("'systemId' mismatch: %s != %s",
+				*(server.GetSystemId()), systemID,
+			),
+		)
+
+		return
+	}
+
 	if server.GetName() == nil {
 		(*diagsP).AddError(
 			"error reading server",


### PR DESCRIPTION
If the system id underpinning a server unexpectedly changes,
raise the following error:

```
Error: error reading server

  with hpegl_pc_server.test,
  on main.tf line 28, in resource "hpegl_pc_server" "test":
  28: resource "hpegl_pc_server" "test" {

'systemId' mismatch: 026fd201-9e6e-5e31-9ffb-a766265b1fd3 !=
126fd201-9e6e-5e31-9ffb-a766265b1fd3
```