### PR TITLE
Avoid duplicate runs of build/lint

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,11 @@
 # Copyright 2024 Hewlett Packard Enterprise Development LP
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,7 +1,11 @@
 # Copyright 2024 Hewlett Packard Enterprise Development LP
 name: Lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
   lint:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Update the relevant github workflows so that
build and lint actions only run once for PRs.