### PR TITLE
Update "datastore create" default parameters

### DIFF
--- a/internal/resources/datastore/resource.go
+++ b/internal/resources/datastore/resource.go
@@ -350,33 +350,33 @@ func doCreate(
 	prb.SetName(&name)
 
 	// TODO: (API) Allow setting cipher when FF-29512 is fixed
-	cipher := datastores.NONE_DATASTORESPOSTREQUESTBODY_VOLUMEINFO_ENCRYPTION_CIPHER
-	enc := virtualization.NewV1beta1DatastoresPostRequestBody_volumeInfo_encryption()
+	// cipher := datastores.NONE_DATASTORESPOSTREQUESTBODY_VOLUMEINFO_ENCRYPTION_CIPHER
+	// enc := virtualization.NewV1beta1DatastoresPostRequestBody_volumeInfo_encryption()
 
 	// TODO: should be able to use enum for cipher (bug in sdk or spec processing?)
-	cipherMap := map[string]any{
-		"cipher": cipher.String(),
-	}
+	//cipherMap := map[string]any{
+	//	"cipher": cipher.String(),
+	//}
 
-	enc.SetAdditionalData(cipherMap)
-	qos := virtualization.NewV1beta1DatastoresPostRequestBody_volumeInfo_qos()
+	// enc.SetAdditionalData(cipherMap)
+	// qos := virtualization.NewV1beta1DatastoresPostRequestBody_volumeInfo_qos()
 	// TODO: (API) Allow setting iopsLimit when FF-29512 is fixed
-	var iopsLimit float64 = -1 // -1 implies no limit
-	qos.SetIopsLimit(&iopsLimit)
+	// var iopsLimit float64 = -1 // -1 implies no limit
+	// qos.SetIopsLimit(&iopsLimit)
 
 	// TODO: (API) Allow setting mbsLimit when FF-29512 is fixed
-	var mbpsLimit float64 = -1 // -1 implies no limit
-	qos.SetMbpsLimit(&mbpsLimit)
+	// var mbpsLimit float64 = -1 // -1 implies no limit
+	// qos.SetMbpsLimit(&mbpsLimit)
 
-	volInfo := virtualization.NewV1beta1DatastoresPostRequestBody_volumeInfo()
+	// volInfo := virtualization.NewV1beta1DatastoresPostRequestBody_volumeInfo()
 
 	// TODO: (API) Allow setting duplication when FF-29512 is fixed
-	False := false
-	volInfo.SetDeduplication(&False)
-	volInfo.SetEncryption(enc)
-	volInfo.SetQos(qos)
+	// False := false
+	// volInfo.SetDeduplication(&False)
+	// volInfo.SetEncryption(enc)
+	// volInfo.SetQos(qos)
 
-	prb.SetVolumeInfo(volInfo)
+	// prb.SetVolumeInfo(volInfo)
 
 	sizeInBytes := (*dataP).CapacityInBytes.ValueInt64()
 	prb.SetSizeInBytes(&sizeInBytes)

--- a/internal/simulator/fixtures/datastores/create/post-request.json
+++ b/internal/simulator/fixtures/datastores/create/post-request.json
@@ -1,1 +1,1 @@
-{"name":"mclaren-ds19","sizeInBytes":17179869184,"storageSystemId":"126fd201-9e6e-5e31-9ffb-a766265b1fd3","targetHypervisorClusterId":"acd4daea-e5e3-5f35-8be3-ce4a4b6d946c","volumeInfo":{"deduplication":false,"encryption":{"cipher":"None"},"qos":{"iopsLimit":1000000,"mbpsLimit":1000000}},"datastoreType":"VMFS"}
+{"name":"mclaren-ds19","sizeInBytes":17179869184,"storageSystemId":"126fd201-9e6e-5e31-9ffb-a766265b1fd3","targetHypervisorClusterId":"acd4daea-e5e3-5f35-8be3-ce4a4b6d946c","datastoreType":"VMFS"}


### PR DESCRIPTION
Previously the following input was accepted by the server:

```
{
  "name": "mclaren-ds19",
  "sizeInBytes": 17179869184,
  "storageSystemId": "126fd201-9e6e-5e31-9ffb-a766265b1fd3",
  "targetHypervisorClusterId": "",
  "volumeInfo": {
    "deduplication": false,
    "encryption": {
      "cipher": "None"
    },
    "qos": {
      "iopsLimit": -1,
      "mbpsLimit": -1
    }
  },
  "datastoreType": "VMFS"
}
```

But this now triggers an error response.

```
NimbleVolumeInfo.Qos.MbpsLimit is less than minimum value. NimbleVolumeInfo.Qos.IopsLimit is less than minimum value.
```

In particular, providing `-1` to imply default values for limits no longer seems to work.

Rather than specifying limits in this way, we now remove them entirely. We also do the same for other parameters (eg encryption) to pick up default values.

The create datastore POST request body will now look like:

```
{
  "name": "datastore-100",
  "sizeInBytes": 17179869184,
  "storageSystemId": "f9689284-0bbd-5bf1-981f-b9799bbc106c",
  "targetHypervisorClusterId": "",
  "datastoreType": "VMFS"
}
```