### PR TITLE
Set `TF_LOG_PATH_MASK` for simulated acceptance tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ testacc-simulation:
 	tfconfig=$$(mktemp); \
 	sed "s@__HOME__@${HOME}@g" test/.terraformrc > $$tfconfig; \
 	env TF_ACC=1 env TF_CLI_CONFIG_FILE=$$tfconfig \
+	env TF_LOG_PATH_MASK=$${tfconfig}.%s.log \
 		go test -v -tags simulation ./test/...
 
 demo:


### PR DESCRIPTION
This results in per-test log files in /tmp such as:

`tmp.1ylrTjx0Ge.TestAccDatastoreResourceOk.log`

These new log files contain the http debug, so we
can now more easily "see" what is happening during these test runs.