### PR TITLE
Fix to allow debug of hypervisor cluster create

### DIFF
--- a/internal/resources/hypervisorcluster/resource.go
+++ b/internal/resources/hypervisorcluster/resource.go
@@ -276,7 +276,7 @@ func doCreate(
 		Systems().
 		ById(systemID).
 		AddHypervisorCluster().
-		Post(context.Background(), prb, &prc)
+		Post(ctx, prb, &prc)
 	if err != nil {
 		(*diagsP).AddError(
 			"error creating hypervisorcluster",


### PR DESCRIPTION
The wrong context was being used which resulted in no logging of the
hypervisor create POST request when http_debug was enabled.