### PR TITLE
Write hypervisor cluster state earlier

### DIFF
--- a/internal/resources/hypervisorcluster/resource.go
+++ b/internal/resources/hypervisorcluster/resource.go
@@ -359,6 +359,8 @@ func (r *Resource) Create(
 	}
 
 	doCreate(ctx, *r.client, &data, &resp.Diagnostics)
+	// Write state to capture the id
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}


### PR DESCRIPTION
Ensure we write the state for a hypervisor cluster create as soon
as possible. This helps avoid the situation where a hypervisor cluster
was created but the id is not captured in the terraform state file.