### PR TITLE
Temporarily hack hypervisor delete SDK code

### DIFF
--- a/internal/sdk/systems/privatecloudbusiness/v1beta1_systems_item_remove_hypervisor_clusters_post_request_body.go
+++ b/internal/sdk/systems/privatecloudbusiness/v1beta1_systems_item_remove_hypervisor_clusters_post_request_body.go
@@ -58,7 +58,7 @@ func (m *V1beta1SystemsItemRemoveHypervisorClustersPostRequestBody) GetHyperviso
 // Serialize serializes information the current object
 func (m *V1beta1SystemsItemRemoveHypervisorClustersPostRequestBody) Serialize(writer i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.SerializationWriter)(error) {
     if m.GetHypervisorClusterIds() != nil {
-        err := writer.WriteCollectionOfStringValues("hypervisorClusterIds", m.GetHypervisorClusterIds())
+        err := writer.WriteCollectionOfStringValues("hypervisor_cluster_ids", m.GetHypervisorClusterIds())
         if err != nil {
             return err
         }


### PR DESCRIPTION
There is currently a bug where the service needs the remove hypervisor cluster
POST request to use snake case for the id field, eg:

```
{"hypervisor_cluster_ids":["50af582d-3b98-570f-b113-650da9d0d633"]}
```

This should not be the case since the OpenAPI spec uses camelCase.
For now switch to use snake_case. Once the service is updated to conform
to the OpenAPI specification we will revert this change.