### PR TITLE
Make handling of test fixtures consistent

### DIFF
--- a/internal/simulator/datastore_create.go
+++ b/internal/simulator/datastore_create.go
@@ -8,6 +8,9 @@ import (
 	"github.com/h2non/gock"
 )
 
+//go:embed fixtures/datastores/create/post-request.json
+var dsPostRequest string
+
 //go:embed fixtures/datastores/create/hypervisorclustersfiltered.json
 var hcFilter string
 
@@ -49,6 +52,8 @@ func datastoreCreate() {
 
 	gock.New("http://localhost").
 		Post("/virtualization/v1beta1/datastore").
+		MatchType("json").
+		BodyString(dsPostRequest).
 		Reply(202).
 		SetHeader("Location", "/data-services/v1beta1/async-operations/"+taskID)
 

--- a/internal/simulator/datastore_delete.go
+++ b/internal/simulator/datastore_delete.go
@@ -29,6 +29,7 @@ func datastoreDelete() {
 
 	gock.New("http://localhost").
 		Delete("/virtualization/v1beta1/datastores/"+datastoreID).
+		BodyString("").
 		Reply(202).
 		SetHeader("Location", "/data-services/v1beta1/async-operations/"+taskID).
 		SetHeader("Content-Type", "application/json").

--- a/internal/simulator/fixtures/datastores/create/post-request.json
+++ b/internal/simulator/fixtures/datastores/create/post-request.json
@@ -1,1 +1,1 @@
-{"name":"mclaren-ds19","sizeInBytes":17179869184,"storageSystemId":"126fd201-9e6e-5e31-9ffb-a766265b1fd3","targetHypervisorClusterId":"acd4daea-e5e3-5f35-8be3-ce4a4b6d946c","datastoreType":"VMFS"}
+{"name":"mclaren-ds19","sizeInBytes":17179869184,"storageSystemId":"126fd201-9e6e-5e31-9ffb-a766265b1fd3","targetHypervisorClusterId":"298a299e-78f5-5acb-86ce-4e9fdc290ab7","datastoreType":"VMFS"}

--- a/internal/simulator/fixtures/hypervisorclusters/delete/post.json
+++ b/internal/simulator/fixtures/hypervisorclusters/delete/post.json
@@ -1,0 +1,1 @@
+{"hypervisor_cluster_ids":["298a299e-78f5-5acb-86ce-4e9fdc290ab7"]}

--- a/internal/simulator/hypervisorcluster_delete.go
+++ b/internal/simulator/hypervisorcluster_delete.go
@@ -8,6 +8,9 @@ import (
 	"github.com/h2non/gock"
 )
 
+//go:embed fixtures/hypervisorclusters/delete/post.json
+var hcDeletePost string
+
 //go:embed fixtures/hypervisorclusters/delete/async1.json
 var deleteTaskOne string
 
@@ -17,13 +20,12 @@ var deleteTaskTwo string
 func hypervisorClusterDelete() {
 	taskID := "a73607cc-ae57-4efe-b573-615813e6c77d"
 	systemID := "126fd201-9e6e-5e31-9ffb-a766265b1fd3"
-	clusterID := "298a299e-78f5-5acb-86ce-4e9fdc290ab7"
 
 	gock.New("http://localhost").
 		Post("/private-cloud-business/v1beta1/systems/"+systemID+
 			"/remove-hypervisor-clusters").
 		MatchType("json").
-		JSON(map[string][]string{"hypervisor_cluster_ids": {clusterID}}).
+		BodyString(hcDeletePost).
 		Reply(202).
 		SetHeader("Location", "/data-services/v1beta1/async-operations/"+taskID)
 


### PR DESCRIPTION
A small change to make handling of POST requests
consistent when testing.

Helps ensure that each client side POST request body is created as expected.