### PR TITLE
Add server: include some networking info

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -31,5 +31,13 @@ resource "hpegl_pc_server" "my_server" {
         hypervisor_cluster_id   = "acd4daea-e5e3-5f35-8be3-ce4a4b6d946c"
         esx_root_credential_id  = "cccfcad1-85b7-4162-b16e-f7cadc2c46b5"
         ilo_admin_credential_id = "dddfcad1-85b7-4162-b16e-f7cadc2c46b5"
-        server_network = []
+        server_network = [
+                {
+                        data_ip_infos = [
+                                {
+                                        ip_address = "16.182.105.217"
+                                }
+                        ]
+                }
+        ]
 }

--- a/internal/simulator/fixtures/servers/create/post.json
+++ b/internal/simulator/fixtures/servers/create/post.json
@@ -1,1 +1,1 @@
-{"esxRootCredentialId":"cccfcad1-85b7-4162-b16e-f7cadc2c46b5","hypervisorClusterId":"acd4daea-e5e3-5f35-8be3-ce4a4b6d946c","iloAdminCredentialId":"dddfcad1-85b7-4162-b16e-f7cadc2c46b5"}
+{"esxRootCredentialId":"cccfcad1-85b7-4162-b16e-f7cadc2c46b5","hypervisorClusterId":"acd4daea-e5e3-5f35-8be3-ce4a4b6d946c","iloAdminCredentialId":"dddfcad1-85b7-4162-b16e-f7cadc2c46b5","serverNetwork":[{"dataIpInfos":[{"ipAddress":"16.182.105.217"}]}]}

--- a/test/server/server_test.go
+++ b/test/server/server_test.go
@@ -69,7 +69,15 @@ func TestAccServerResource(t *testing.T) {
 	        hypervisor_cluster_id   = "acd4daea-e5e3-5f35-8be3-ce4a4b6d946c"
 	        esx_root_credential_id  = "cccfcad1-85b7-4162-b16e-f7cadc2c46b5"
 	        ilo_admin_credential_id = "dddfcad1-85b7-4162-b16e-f7cadc2c46b5"
-	        server_network = []
+	        server_network = [
+	                {
+	                        data_ip_infos = [
+	                                {
+	                                        ip_address = "16.182.105.217"
+	                                }
+	                        ]
+	                }
+	        ]
 	}
 	`
 


### PR DESCRIPTION
Add initial networking information for the add-hypervisor-server request.

Note: there are currently some mis-matches between the OpenAPI spec
and the server implemenation for add-hypervisor-server. This code matches
the OpenAPI specification.