### PR TITLE
Server update attributes

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -26,11 +26,15 @@ resource "hpegl_pc_hypervisor_cluster" "my_hypervisor_cluster" {
   }
 }
 
-resource "hpegl_pc_server" "my_server" {
-        system_id = data.hpegl_pc_system.my_system.id
-        hypervisor_cluster_id   = "acd4daea-e5e3-5f35-8be3-ce4a4b6d946c"
+
+resource "hpegl_pc_server" "test" {
+        system_id   = "126fd201-9e6e-5e31-9ffb-a766265b1fd3"
         esx_root_credential_id  = "cccfcad1-85b7-4162-b16e-f7cadc2c46b5"
         ilo_admin_credential_id = "dddfcad1-85b7-4162-b16e-f7cadc2c46b5"
+        hypervisor_host = {
+                hypervisor_cluster_id = "acd4daea-e5e3-5f35-8be3-ce4a4b6d946c"
+                hypervisor_host_ip = "16.182.105.217"
+        }
         server_network = [
                 {
                         data_ip_infos = [

--- a/test/server/server_test.go
+++ b/test/server/server_test.go
@@ -77,9 +77,12 @@ func TestAccServerResource(t *testing.T) {
 	config := providerConfig + `
 	resource "hpegl_pc_server" "test" {
 	        system_id   = "126fd201-9e6e-5e31-9ffb-a766265b1fd3"
-	        hypervisor_cluster_id   = "acd4daea-e5e3-5f35-8be3-ce4a4b6d946c"
 	        esx_root_credential_id  = "cccfcad1-85b7-4162-b16e-f7cadc2c46b5"
 	        ilo_admin_credential_id = "dddfcad1-85b7-4162-b16e-f7cadc2c46b5"
+	        hypervisor_host = {
+	                hypervisor_cluster_id = "acd4daea-e5e3-5f35-8be3-ce4a4b6d946c"
+	                hypervisor_host_ip = "16.182.105.217"
+	        }
 	        server_network = [
 	                {
 	                        data_ip_infos = [
@@ -102,11 +105,24 @@ func TestAccServerResource(t *testing.T) {
 			"hpegl_pc_server.test",
 			"name",
 		),
+		resource.TestCheckResourceAttrSet(
+			"hpegl_pc_server.test",
+			"hypervisor_host.name",
+		),
+		resource.TestCheckResourceAttrSet(
+			"hpegl_pc_server.test",
+			"hypervisor_host.hypervisor_cluster_name",
+		),
+		resource.TestCheckResourceAttrSet(
+			"hpegl_pc_server.test",
+			"hypervisor_host.hypervisor_host_ip",
+		),
 		checkUUIDAttr("hpegl_pc_server.test", "id"),
 		checkUUIDAttr("hpegl_pc_server.test", "system_id"),
-		checkUUIDAttr("hpegl_pc_server.test", "hypervisor_cluster_id"),
 		checkUUIDAttr("hpegl_pc_server.test", "esx_root_credential_id"),
 		checkUUIDAttr("hpegl_pc_server.test", "ilo_admin_credential_id"),
+		checkUUIDAttr("hpegl_pc_server.test", "hypervisor_host.hypervisor_cluster_id"),
+		checkUUIDAttr("hpegl_pc_server.test", "hypervisor_host.id"),
 	}
 
 	if simulation {
@@ -123,11 +139,6 @@ func TestAccServerResource(t *testing.T) {
 			),
 			resource.TestCheckResourceAttr(
 				"hpegl_pc_server.test",
-				"hypervisor_cluster_id",
-				"acd4daea-e5e3-5f35-8be3-ce4a4b6d946c",
-			),
-			resource.TestCheckResourceAttr(
-				"hpegl_pc_server.test",
 				"esx_root_credential_id",
 				"cccfcad1-85b7-4162-b16e-f7cadc2c46b5",
 			),
@@ -139,6 +150,31 @@ func TestAccServerResource(t *testing.T) {
 			resource.TestCheckResourceAttr(
 				"hpegl_pc_server.test",
 				"name",
+				"16.182.105.217",
+			),
+			resource.TestCheckResourceAttr(
+				"hpegl_pc_server.test",
+				"hypervisor_host.hypervisor_cluster_id",
+				"acd4daea-e5e3-5f35-8be3-ce4a4b6d946c",
+			),
+			resource.TestCheckResourceAttr(
+				"hpegl_pc_server.test",
+				"hypervisor_host.hypervisor_cluster_name",
+				"5305-CL",
+			),
+			resource.TestCheckResourceAttr(
+				"hpegl_pc_server.test",
+				"hypervisor_host.name",
+				"16.182.105.217",
+			),
+			resource.TestCheckResourceAttr(
+				"hpegl_pc_server.test",
+				"hypervisor_host.id",
+				"530b1894-9bd0-5627-9362-565aff1e5cbd",
+			),
+			resource.TestCheckResourceAttr(
+				"hpegl_pc_server.test",
+				"hypervisor_host.hypervisor_host_ip",
 				"16.182.105.217",
 			),
 		)


### PR DESCRIPTION
Add attributes to server
    
Add some additional attributes to the server model.
    
Re-position some attributes to more closely match the
json response of GET .../server/<id>. This means that
the terraform code will more closely resemble the REST
state.

Note: Two commits - first commit is auto-generated code.