### PR TITLE
Query filter for /secrets should use single quotes

### DIFF
--- a/internal/datasources/secret/data_source.go
+++ b/internal/datasources/secret/data_source.go
@@ -62,7 +62,7 @@ func (s *DataSource) Configure(
 }
 
 func createNameFilter(name string) string {
-	return constants.NameFilter + name
+	return constants.NameFilter + "'" + name + "'"
 }
 
 func getSecretByName(

--- a/internal/simulator/secret.go
+++ b/internal/simulator/secret.go
@@ -18,7 +18,7 @@ func simulateSecretGetByName() {
 
 	gock.New("http://localhost").
 		Get("/data-services/v1beta1/secrets").
-		MatchParam("filter", "name eq "+secretName).
+		MatchParam("filter", "name eq "+"'"+secretName+"'").
 		MatchHeader("Authorization", "Bearer abcdefghijklmnopqrstuvwxyz-0123456789").
 		Reply(200).
 		SetHeader("Content-Type", "application/json").
@@ -26,7 +26,7 @@ func simulateSecretGetByName() {
 
 	gock.New("http://localhost").
 		Get("/data-services/v1beta1/secrets").
-		MatchParam("filter", "name eq "+secretName).
+		MatchParam("filter", "name eq "+"'"+secretName+"'").
 		MatchHeader("Authorization", "Bearer expired-token").
 		Reply(401).
 		SetHeader("Content-Type", "text/plain").


### PR DESCRIPTION
Unlike other resources, when filtering secrets by
name, the name should be surrounded by single quotes.

If no quotes are present the following error is returned:

```
{"httpStatusCode":400,"errorCode":"HPE_GL_DATA_SERVICES_INVALID_PARAMETER","message":"unsupported OData filter \"name eq foo\" due to unsupported OData comparison value type (must be String)","debugId":"f461e8f8dc017a5fca7d6a6c404c0016"}
```