### PR TITLE
Add partial support for import server

### DIFF
--- a/test/server/server_test.go
+++ b/test/server/server_test.go
@@ -4,6 +4,7 @@ package acceptance
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/HewlettPackard/hpegl-pcbe-terraform-resources/internal/provider"
@@ -253,6 +254,72 @@ func TestAccServerResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResourceDestroyed("hpegl_pc_server.test"),
 				),
+			},
+			{
+				// Import
+				Check:              checkFn,
+				Config:             config,
+				ImportState:        true,
+				ResourceName:       "hpegl_pc_server.test",
+				ImportStateId:      "126fd201-9e6e-5e31-9ffb-a766265b1fd3,697e8cbf-df7e-570c-a3c7-912d4ce8375a",
+				ImportStatePersist: true,
+			},
+			/*
+				TODO: (API) This test cannot currently pass.
+				See FF-31582 FF-31587 FF-31581 PC-6095 etc
+				{
+					// Check post import state matches the resource config
+					// e.g. verfies 'name' in state matches 'name' in config
+					Config:             config,
+					Check:              checkFn,
+					ExpectNonEmptyPlan: false,
+				},
+			*/
+		},
+	})
+}
+
+func TestAccServerImportBadId(t *testing.T) {
+	config := providerConfig + `
+	resource "hpegl_pc_server" "test" {
+	        system_id   = "126fd201-9e6e-5e31-9ffb-a766265b1fd3"
+	        esx_root_credential_id  = "cccfcad1-85b7-4162-b16e-f7cadc2c46b5"
+	        ilo_admin_credential_id = "dddfcad1-85b7-4162-b16e-f7cadc2c46b5"
+	        hypervisor_host = {
+	                hypervisor_cluster_id = "acd4daea-e5e3-5f35-8be3-ce4a4b6d946c"
+	                hypervisor_host_ip = "16.182.105.217"
+	        }
+	        ilo_network_info = {
+	                ilo_ip = "16.182.105.216"
+	                gateway = "16.182.104.1"
+	                subnet_mask = "255.255.248.0"
+	        }
+	        server_network = [
+	                {
+	                        esx_ip_address = "10.0.0.88"
+	                        data_ip_infos = [
+	                                {
+	                                        ip_address = "16.182.105.217"
+	                                }
+	                        ]
+	                }
+	        ]
+	}
+	`
+
+	expected := `import has invalid server id format(.|\n)*698de955-87b5-5fe6-b683-78c3948beede`
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Import
+				ExpectError:  regexp.MustCompile(expected),
+				Config:       config,
+				ImportState:  true,
+				ResourceName: "hpegl_pc_server.test",
+				// Invalid id (not "<cluster id>,<datastore id>")
+				ImportStateId:      "698de955-87b5-5fe6-b683-78c3948beede",
+				ImportStatePersist: true,
 			},
 		},
 	})


### PR DESCRIPTION
Running

```
terraform import hpegl_pc_server.test 126fd201-9e6e-5e31-9ffb-a766265b1fd3,697e8cbf-df7e-570c-a3c7-912d4ce8375a
```

will partially update the state file. Some fields are missing

* esx_root_credential_id
* ilo_admin_credential_id
* server_network

these fields are not currently retrievable via the API, so they will be set to `null` in the state. This will lead to an error if a "terraform apply" is subsequently run, unless these fields are manually tweaked.

This means that "terraform import" for server resources is only partially supported.