### PR TITLE
Changes to hypervisor cluster delete

### DIFF
--- a/internal/resources/datastore/resource.go
+++ b/internal/resources/datastore/resource.go
@@ -616,7 +616,12 @@ func (r *Resource) Delete(
 	location := virtHeaderOpts.GetResponseHeaders().Get("Location")[0]
 	virtHeaderOpts.ResponseHeaders.Clear()
 	operationID := path.Base(location)
-	asyncOperation := async.New(ctx, client, operationID, constants.TaskDatastore)
+	asyncOperation := async.New(
+		ctx,
+		client,
+		operationID,
+		constants.TaskDatastore,
+	)
 	err = asyncOperation.Poll()
 	if err != nil {
 		resp.Diagnostics.AddError(


### PR DESCRIPTION
Update delete behaviour to ensure correct behaviour when failures occur.

Note: if Delete() returns without raising an error, terraform will remove
the relevant state. Conversely, no state will be removed if Delete() returns an error.

See ./docs/dev/state.md