### PR TITLE
Make server name required

### DIFF
--- a/internal/resources/server/server_resource_gen.go
+++ b/internal/resources/server/server_resource_gen.go
@@ -92,7 +92,7 @@ func ServerResourceSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "ilo network information",
 			},
 			"name": schema.StringAttribute{
-				Computed:            true,
+				Required:            true,
 				Description:         "A system specified name for the resource.",
 				MarkdownDescription: "A system specified name for the resource.",
 			},


### PR DESCRIPTION
Required so that we can establish if a server exists or not without knowing its id.

Related to ensuring server failure behaviour matches ./docs/dev/state.md